### PR TITLE
Added a null check for statements

### DIFF
--- a/policies/iam/iam-no-admin-privileges-allowed-by-policies.sentinel
+++ b/policies/iam/iam-no-admin-privileges-allowed-by-policies.sentinel
@@ -39,8 +39,7 @@ fetch_policies_allowing_admin_privileges = func() {
 	policy_documents = tf.state(tfstate.resources).type(const.resource_aws_iam_policy_document).mode(const.data).resources
 
 	for policy_documents as _, iam_policy_document {
-		if iam_policy_document.values is not defined or
-			iam_policy_document.values[const.statement] is not defined {
+		if iam_policy_document.values is not defined or iam_policy_document.values[const.statement] is not defined or iam_policy_document.values[const.statement] is null {
 			continue
 		}
 

--- a/policies/iam/test/iam-no-admin-privileges-allowed-by-policies/mocks/policy-success-policy-with-no-statements/mock-tfconfig-v2.sentinel
+++ b/policies/iam/test/iam-no-admin-privileges-allowed-by-policies/mocks/policy-success-policy-with-no-statements/mock-tfconfig-v2.sentinel
@@ -1,0 +1,80 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_iam_policy.example": {
+		"address": "aws_iam_policy.example",
+		"config": {
+			"name": {
+				"constant_value": "example_policy",
+			},
+			"path": {
+				"constant_value": "/",
+			},
+			"policy": {
+				"references": [
+					"data.aws_iam_policy_document.example.json",
+					"data.aws_iam_policy_document.example",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy",
+	},
+	"data.aws_iam_policy_document.example": {
+		"address": "data.aws_iam_policy_document.example",
+		"config": {
+			"policy_id": {
+				"constant_value": "example_policy",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "data",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_iam_policy_document",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/iam/test/iam-no-admin-privileges-allowed-by-policies/mocks/policy-success-policy-with-no-statements/mock-tfstate-v2.sentinel
+++ b/policies/iam/test/iam-no-admin-privileges-allowed-by-policies/mocks/policy-success-policy-with-no-statements/mock-tfstate-v2.sentinel
@@ -1,0 +1,30 @@
+terraform_version = "1.10.2"
+
+outputs = {}
+
+resources = {
+	"aws_iam_policy_document.example": {
+		"address":        "aws_iam_policy_document.example",
+		"depends_on":     [],
+		"deposed_key":    "",
+		"index":          null,
+		"mode":           "data",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"tainted":        false,
+		"type":           "aws_iam_policy_document",
+		"values": {
+			"id":                        "35871773",
+			"json":                      "{\n  \"Version\": \"2012-10-17\",\n  \"Id\": \"example_policy\"\n}",
+			"minified_json":             "{\"Version\":\"2012-10-17\",\"Id\":\"example_policy\"}",
+			"override_json":             null,
+			"override_policy_documents": null,
+			"policy_id":                 "example_policy",
+			"source_json":               null,
+			"source_policy_documents":   null,
+			"statement":                 null,
+			"version":                   "2012-10-17",
+		},
+	},
+}

--- a/policies/iam/test/iam-no-admin-privileges-allowed-by-policies/success-policy-with-no-statements.hcl
+++ b/policies/iam/test/iam-no-admin-privileges-allowed-by-policies/success-policy-with-no-statements.hcl
@@ -1,0 +1,32 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+	module {
+		source = "./mocks/policy-success-policy-with-no-statements/mock-tfconfig-v2.sentinel"
+	}
+}
+
+mock "tfstate/v2" {
+	module {
+		source = "./mocks/policy-success-policy-with-no-statements/mock-tfstate-v2.sentinel"
+	}
+}
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+	rules = {
+		main = true
+	}
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added a null check for statements in IAM policy document for "iam-no-admin-privileges-allowed-by-policies" policy

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-1)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-1)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added