### PR TITLE
Fix CI - Update machine for CI - updated the runs-on to use ubuntu-latest instead of self managed machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 jobs:
   sentinel-fmt-and-test:
-    runs-on: ['self-hosted', 'ondemand', 'os=linux']
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.5


### PR DESCRIPTION
## Changes proposed in this PR:
- Fix CI - Update machine for CI - updated the `runs-on` to use `ubuntu-latest` instead of self managed machines. 

## Checklist:
- [x] Tests added