### PR TITLE
Added the ACL check for the Cloudtrail logs s3 bucket should not be public

### DIFF
--- a/policies/cloudtrail/cloudtrail-logs-bucket-not-public.sentinel
+++ b/policies/cloudtrail/cloudtrail-logs-bucket-not-public.sentinel
@@ -17,7 +17,9 @@ const = {
 	"policy_name":                            "cloudtrail-logs-bucket-not-public",
 	"message":                                "S3 bucket used to store cloudtrail logs must not be publicly accessible. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-6 for more details.",
 	"resource_aws_cloudtrail":                "aws_cloudtrail",
+	"resource_aws_s3_bucket":                 "aws_s3_bucket",
 	"resource_s3_bucket_public_access_block": "aws_s3_bucket_public_access_block",
+	"resource_aws_s3_bucket_acl":             "aws_s3_bucket_acl",
 	"constant_value":                         "constant_value",
 }
 
@@ -64,6 +66,8 @@ resolve_s3_bucket_name = func(bucket_exp, module_address) {
 config_resources = tf.config(tfconfig.resources)
 
 s3_bucket_public_access_block_res = config_resources.type(const.resource_s3_bucket_public_access_block).resources
+s3_bucket_acl_res = config_resources.type(const.resource_aws_s3_bucket_acl).resources
+s3_bucket_inline_acl_res = config_resources.type(const.resource_aws_s3_bucket).resources
 
 compliant_s3_bucket_public_access_block_resources = collection.reject(s3_bucket_public_access_block_res, func(res) {
 	return not (maps.get(res, "config.ignore_public_acls.constant_value", false) and
@@ -72,9 +76,27 @@ compliant_s3_bucket_public_access_block_resources = collection.reject(s3_bucket_
 		maps.get(res, "config.block_public_policy.constant_value", false))
 })
 
+compliant_s3_bucket_acl_block_resources = collection.reject(s3_bucket_acl_res, func(res) {
+	acl_value = maps.get(res, "config.acl", "")
+	if acl_value == "" {
+		return true
+	}
+	return not (maps.get(acl_value, "constant_value", "") == "private")
+})
+
+compliant_s3_bucket_inline_acl_block_resources = collection.reject(s3_bucket_inline_acl_res, func(res) {
+	acl_value = maps.get(res, "config.acl", "")
+	if acl_value == "" {
+		return true
+	}
+	return not (maps.get(acl_value, "constant_value", "") == "private")
+})
+
+compliant_s3_bucket_resources = compliant_s3_bucket_public_access_block_resources + compliant_s3_bucket_acl_block_resources + compliant_s3_bucket_inline_acl_block_resources
+
 private_bucket_names = []
 
-for compliant_s3_bucket_public_access_block_resources as _, res {
+for compliant_s3_bucket_resources as _, res {
 	bucket_name = resolve_s3_bucket_name(maps.get(res, "config.bucket", {}), res.module_address)
 	if bucket_name is not empty {
 		append(private_bucket_names, bucket_name)

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/failure-cloudtrail-has-public-s3-bucket-with-acl-resource.hcl
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/failure-cloudtrail-has-public-s3-bucket-with-acl-resource.hcl
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-cloudtrail-has-public-s3-bucket-with-acl-resource/mock-tfconfig-v2.sentinel"
+  }
+}
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/failure-cloudtrail-has-public-s3-bucket-with-inline-acl.hcl
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/failure-cloudtrail-has-public-s3-bucket-with-inline-acl.hcl
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-cloudtrail-has-public-s3-bucket-with-inline-acl/mock-tfconfig-v2.sentinel"
+  }
+}
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-failure-cloudtrail-has-public-s3-bucket-with-acl-resource/mock-tfconfig-v2.sentinel
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-failure-cloudtrail-has-public-s3-bucket-with-acl-resource/mock-tfconfig-v2.sentinel
@@ -1,0 +1,118 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_cloudtrail.example": {
+		"address": "aws_cloudtrail.example",
+		"config": {
+			"enable_log_file_validation": {
+				"constant_value": true,
+			},
+			"enable_logging": {
+				"constant_value": true,
+			},
+			"include_global_service_events": {
+				"constant_value": true,
+			},
+			"is_multi_region_trail": {
+				"constant_value": true,
+			},
+			"name": {
+				"constant_value": "example",
+			},
+			"s3_bucket_name": {
+				"references": [
+					"aws_s3_bucket.bucket.bucket",
+					"aws_s3_bucket.bucket",
+				],
+			},
+			"s3_key_prefix": {
+				"constant_value": "cloudtrail",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudtrail",
+	},
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"config": {
+			"bucket": {
+				"constant_value": "my-tf-test-bucket",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_s3_bucket_acl.bucket_acl": {
+		"address": "aws_s3_bucket_acl.bucket_acl",
+		"config": {
+			"acl": {
+				"constant_value": "public-read",
+			},
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.bucket.bucket",
+					"aws_s3_bucket.bucket",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket_acl",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_acl",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-failure-cloudtrail-has-public-s3-bucket-with-inline-acl/mock-tfconfig-v2.sentinel
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-failure-cloudtrail-has-public-s3-bucket-with-inline-acl/mock-tfconfig-v2.sentinel
@@ -1,0 +1,98 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_cloudtrail.example": {
+		"address": "aws_cloudtrail.example",
+		"config": {
+			"enable_log_file_validation": {
+				"constant_value": true,
+			},
+			"enable_logging": {
+				"constant_value": true,
+			},
+			"include_global_service_events": {
+				"constant_value": true,
+			},
+			"is_multi_region_trail": {
+				"constant_value": true,
+			},
+			"name": {
+				"constant_value": "example",
+			},
+			"s3_bucket_name": {
+				"references": [
+					"aws_s3_bucket.bucket.bucket",
+					"aws_s3_bucket.bucket",
+				],
+			},
+			"s3_key_prefix": {
+				"constant_value": "cloudtrail",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudtrail",
+	},
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"config": {
+			"acl": {
+				"constant_value": "public-read",
+			},
+			"bucket": {
+				"constant_value": "my-tf-test-bucket",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-success-cloudtrail-has-private-s3-bucket-with-acl-resource/mock-tfconfig-v2.sentinel
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-success-cloudtrail-has-private-s3-bucket-with-acl-resource/mock-tfconfig-v2.sentinel
@@ -1,0 +1,118 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_cloudtrail.example": {
+		"address": "aws_cloudtrail.example",
+		"config": {
+			"enable_log_file_validation": {
+				"constant_value": true,
+			},
+			"enable_logging": {
+				"constant_value": true,
+			},
+			"include_global_service_events": {
+				"constant_value": true,
+			},
+			"is_multi_region_trail": {
+				"constant_value": true,
+			},
+			"name": {
+				"constant_value": "example",
+			},
+			"s3_bucket_name": {
+				"references": [
+					"aws_s3_bucket.bucket.bucket",
+					"aws_s3_bucket.bucket",
+				],
+			},
+			"s3_key_prefix": {
+				"constant_value": "cloudtrail",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudtrail",
+	},
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"config": {
+			"bucket": {
+				"constant_value": "my-tf-test-bucket",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_s3_bucket_acl.bucket_acl": {
+		"address": "aws_s3_bucket_acl.bucket_acl",
+		"config": {
+			"acl": {
+				"constant_value": "private",
+			},
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.bucket.bucket",
+					"aws_s3_bucket.bucket",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket_acl",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_acl",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-success-cloudtrail-has-private-s3-bucket-with-inline-acl/mock-tfconfig-v2.sentinel
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/mocks/policy-success-cloudtrail-has-private-s3-bucket-with-inline-acl/mock-tfconfig-v2.sentinel
@@ -1,0 +1,98 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_cloudtrail.example": {
+		"address": "aws_cloudtrail.example",
+		"config": {
+			"enable_log_file_validation": {
+				"constant_value": true,
+			},
+			"enable_logging": {
+				"constant_value": true,
+			},
+			"include_global_service_events": {
+				"constant_value": true,
+			},
+			"is_multi_region_trail": {
+				"constant_value": true,
+			},
+			"name": {
+				"constant_value": "example",
+			},
+			"s3_bucket_name": {
+				"references": [
+					"aws_s3_bucket.bucket.bucket",
+					"aws_s3_bucket.bucket",
+				],
+			},
+			"s3_key_prefix": {
+				"constant_value": "cloudtrail",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudtrail",
+	},
+	"aws_s3_bucket.bucket": {
+		"address": "aws_s3_bucket.bucket",
+		"config": {
+			"acl": {
+				"constant_value": "private",
+			},
+			"bucket": {
+				"constant_value": "my-tf-test-bucket",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "bucket",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/success-cloudtrail-has-private-s3-bucket-with-acl-resource.hcl
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/success-cloudtrail-has-private-s3-bucket-with-acl-resource.hcl
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-success-cloudtrail-has-private-s3-bucket-with-acl-resource/mock-tfconfig-v2.sentinel"
+  }
+}
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/success-cloudtrail-has-private-s3-bucket-with-inline-acl.hcl
+++ b/policies/cloudtrail/test/cloudtrail-logs-bucket-not-public/success-cloudtrail-has-private-s3-bucket-with-inline-acl.hcl
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-success-cloudtrail-has-private-s3-bucket-with-inline-acl/mock-tfconfig-v2.sentinel"
+  }
+}
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added the ACL check for the Cloudtrail logs s3 bucket should not be public
-

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-6)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-6)

## AWS Provider version

## How I've tested this PR:

## Checklist:
- [x] Tests added