### PR TITLE
Add a versioning disabled test in s3-require-mfa-delete policy

### DIFF
--- a/policies/s3/s3-require-mfa-delete.sentinel
+++ b/policies/s3/s3-require-mfa-delete.sentinel
@@ -24,7 +24,7 @@ const = {
 	"resource_aws_s3_bucket_versioning": "aws_s3_bucket_versioning",
 	"status":     "status",
 	"mfa_delete": "mfa_delete",
-	"Enabled":    "Enabled",
+	"enabled":    "Enabled",
 	"message":    "All 'aws_s3_bucket' resources should be linked to 'aws_s3_bucket_versioning' resources with 'mfa_delete' set to 'Enabled'. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-20 for more details.",
 }
 
@@ -33,16 +33,16 @@ const = {
 check_mfa_from_refrence_var = func(config) {
 	return config.mfa_delete["references"] is defined and
 		tfconfig.is_variable_reference(config.mfa_delete.references[0]) and
-		tfplan.get_variable_value(tfconfig.parse_variable_name_from_reference(config.mfa_delete.references[0])) is const.Enabled
+		tfplan.get_variable_value(tfconfig.parse_variable_name_from_reference(config.mfa_delete.references[0])) is const.enabled
 }
 
 check_mfa_from_const = func(config) {
-	return config.mfa_delete["constant_value"] is defined and config.mfa_delete.constant_value is const.Enabled
+	return config.mfa_delete["constant_value"] is defined and config.mfa_delete.constant_value is const.enabled
 }
 
 is_mfa_enabled = func(res) {
 	return collection.find(res.config.versioning_configuration, func(config) {
-		return config.status.constant_value is const.Enabled and
+		return config.status.constant_value is const.enabled and
 			config[const.mfa_delete] is defined and
 			(check_mfa_from_const(config) or check_mfa_from_refrence_var(config))
 	}) is defined

--- a/policies/s3/s3-require-mfa-delete.sentinel
+++ b/policies/s3/s3-require-mfa-delete.sentinel
@@ -22,9 +22,10 @@ const = {
 	"module_prefix":                     "module.",
 	"resource_aws_s3_bucket":            "aws_s3_bucket",
 	"resource_aws_s3_bucket_versioning": "aws_s3_bucket_versioning",
-	"mfa_delete":                        "mfa_delete",
-	"Enabled":                           "Enabled",
-	"message":                           "All 'aws_s3_bucket' resources should be linked to 'aws_s3_bucket_versioning' resources with 'mfa_delete' set to 'Enabled'. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-20 for more details.",
+	"status":     "status",
+	"mfa_delete": "mfa_delete",
+	"Enabled":    "Enabled",
+	"message":    "All 'aws_s3_bucket' resources should be linked to 'aws_s3_bucket_versioning' resources with 'mfa_delete' set to 'Enabled'. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-20 for more details.",
 }
 
 # Functions
@@ -41,7 +42,8 @@ check_mfa_from_const = func(config) {
 
 is_mfa_enabled = func(res) {
 	return collection.find(res.config.versioning_configuration, func(config) {
-		return config[const.mfa_delete] is defined and
+		return config.status.constant_value is const.Enabled and
+			config[const.mfa_delete] is defined and
 			(check_mfa_from_const(config) or check_mfa_from_refrence_var(config))
 	}) is defined
 }

--- a/policies/s3/test/s3-require-mfa-delete/failure-versioning-disabled.hcl
+++ b/policies/s3/test/s3-require-mfa-delete/failure-versioning-disabled.hcl
@@ -1,0 +1,44 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/failure-versioning-disabled/mock-tfconfig-v2.sentinel"
+  }
+}
+
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/failure-versioning-disabled/mock-tfplan-v2.sentinel"
+  }
+}
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "tfconfig-functions" {
+  module {
+    source = "../../../../modules/tfconfig-functions/tfconfig-functions.sentinel"
+  }
+}
+
+mock "tfplan-functions" {
+  module {
+    source = "../../../../modules/tfplan-functions/tfplan-functions.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/s3/test/s3-require-mfa-delete/mocks/failure-versioning-disabled/mock-tfconfig-v2.sentinel
+++ b/policies/s3/test/s3-require-mfa-delete/mocks/failure-versioning-disabled/mock-tfconfig-v2.sentinel
@@ -1,0 +1,110 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_s3_bucket.example": {
+		"address": "aws_s3_bucket.example",
+		"config": {
+			"bucket": {
+				"constant_value": "example-bucket",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket",
+	},
+	"aws_s3_bucket_acl.example": {
+		"address": "aws_s3_bucket_acl.example",
+		"config": {
+			"acl": {
+				"constant_value": "private",
+			},
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.example.id",
+					"aws_s3_bucket.example",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_acl",
+	},
+	"aws_s3_bucket_versioning.versioning_example": {
+		"address": "aws_s3_bucket_versioning.versioning_example",
+		"config": {
+			"bucket": {
+				"references": [
+					"aws_s3_bucket.example.id",
+					"aws_s3_bucket.example",
+				],
+			},
+			"versioning_configuration": [
+				{
+					"mfa_delete": {
+						"constant_value": "Enabled",
+					},
+					"status": {
+						"constant_value": "Disabled",
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "versioning_example",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_s3_bucket_versioning",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/s3/test/s3-require-mfa-delete/mocks/failure-versioning-disabled/mock-tfplan-v2.sentinel
+++ b/policies/s3/test/s3-require-mfa-delete/mocks/failure-versioning-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,4 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+variables = {}


### PR DESCRIPTION
## Changes proposed in this PR:
- Add a versioning disabled test in s3-require-mfa-delete policy

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-20)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-20)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [ ] Tests added