### PR TITLE
feat: move Refer to URLs from violation messages to header comments

### DIFF
--- a/policies/cloudtrail/cloudtrail-bucket-access-logging-enabled.sentinel
+++ b/policies/cloudtrail/cloudtrail-bucket-access-logging-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires that resources of type `aws_cloudtrail` have bucket access logging enabled.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-7 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":                "cloudtrail-bucket-access-logging-enabled",
-	"message":                    "Cloudtrail S3 buckets must have access logging enabled. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-7 for more details.",
+	"message":                    "Cloudtrail S3 buckets must have access logging enabled",
 	"resource_aws_cloudtrail":    "aws_cloudtrail",
 	"resource_s3_bucket_logging": "aws_s3_bucket_logging",
 	"constant_value":             "constant_value",

--- a/policies/cloudtrail/cloudtrail-cloudwatch-logs-group-arn-present.sentinel
+++ b/policies/cloudtrail/cloudtrail-cloudwatch-logs-group-arn-present.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type `aws_cloudtrail` to have CloudWatch log group ARN set.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-5 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"resource_aws_cloudtrail": "aws_cloudtrail",
-	"message":                 "Attribute 'cloud_watch_logs_group_arn' must be present for 'aws_cloudtrail' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-5 for more details.",
+	"message":                 "Attribute 'cloud_watch_logs_group_arn' must be present for 'aws_cloudtrail' resources",
 	"policy_name":             "cloudtrail-cloudwatch-logs-group-arn-present",
 	"constant_value":          "constant_value",
 	"logs_group_arn":          "cloud_watch_logs_group_arn",

--- a/policies/cloudtrail/cloudtrail-log-file-validation-enabled.sentinel
+++ b/policies/cloudtrail/cloudtrail-log-file-validation-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type `aws_cloudtrail` to have log file validation enabled.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-4 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":                "cloudtrail-log-file-validation-enabled",
-	"message":                    "Attribute 'enable_log_file_validation' must be true for 'aws_cloudtrail' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-4 for more details.",
+	"message":                    "Attribute 'enable_log_file_validation' must be true for 'aws_cloudtrail' resources",
 	"resource_aws_cloudtrail":    "aws_cloudtrail",
 	"enable_log_file_validation": "enable_log_file_validation",
 }

--- a/policies/cloudtrail/cloudtrail-logs-bucket-not-public.sentinel
+++ b/policies/cloudtrail/cloudtrail-logs-bucket-not-public.sentinel
@@ -1,4 +1,5 @@
 # This policy requires the S3 bucket associated with a CloudTrail to be not publicly accessible.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-6 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":                            "cloudtrail-logs-bucket-not-public",
-	"message":                                "S3 bucket used to store cloudtrail logs must not be publicly accessible. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-6 for more details.",
+	"message":                                "S3 bucket used to store cloudtrail logs must not be publicly accessible",
 	"resource_aws_cloudtrail":                "aws_cloudtrail",
 	"resource_aws_s3_bucket":                 "aws_s3_bucket",
 	"resource_s3_bucket_public_access_block": "aws_s3_bucket_public_access_block",

--- a/policies/cloudtrail/cloudtrail-server-side-encryption-enabled.sentinel
+++ b/policies/cloudtrail/cloudtrail-server-side-encryption-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires that resources of type `aws_cloudtrail` have server-side encryption enabled.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-2 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -16,7 +17,7 @@ import "collection/maps" as maps
 const = {
 	"resource_aws_cloudtrail":         "aws_cloudtrail",
 	"policy_name":                     "cloudtrail-server-side-encryption-enabled",
-	"message":                         "Attribute 'kms_key_id' must be present for 'aws_cloudtrail' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudtrail-controls.html#cloudtrail-2 for more details.",
+	"message":                         "Attribute 'kms_key_id' must be present for 'aws_cloudtrail' resources",
 	"cloudtrail_attribute_kms_key_id": "kms_key_id",
 	"constant_value":                  "constant_value",
 }

--- a/policies/ec2/ec2-ebs-encryption-enabled.sentinel
+++ b/policies/ec2/ec2-ebs-encryption-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type `aws_ebs_volume` have the `encrypted` attribute set to `true`.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-7 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -14,7 +15,7 @@ import "collection/maps" as maps
 # Constants
 const = {
 	"policy_name": "ec2-ebs-encryption-enabled",
-	"message":     "Attribute 'encrypted' must be set to true for 'aws_ebs_volume' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-7 for more details.",
+	"message":     "Attribute 'encrypted' must be set to true for 'aws_ebs_volume' resources",
 	"encrypted":   "encrypted",
 }
 

--- a/policies/ec2/ec2-metadata-imdsv2-required.sentinel
+++ b/policies/ec2/ec2-metadata-imdsv2-required.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type 'aws_instance' or 'aws_ec2_instance_metadata_defaults' to have 'http_tokens' attribute set to 'required'.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name": "ec2-metadata-imdsv2-required",
-	"message":     "Attribute 'http_tokens' must be set to 'required' for all 'aws_instance' resources if 'metadata_options' is used.Else 'aws_ec2_instance_metadata_defaults' resource should have 'http_tokens' set to 'required'. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8 for more details.",
+	"message":     "Attribute 'http_tokens' must be set to 'required' for all 'aws_instance' resources if 'metadata_options' is used.Else 'aws_ec2_instance_metadata_defaults' resource should have 'http_tokens' set to 'required'",
 	"aws_ec2_instance_metadata_defaults": "aws_ec2_instance_metadata_defaults",
 	"aws_instance":                       "aws_instance",
 	"metadata_options":                   "metadata_options",

--- a/policies/ec2/ec2-network-acl.sentinel
+++ b/policies/ec2/ec2-network-acl.sentinel
@@ -1,5 +1,6 @@
 # This policy requires resources of type `aws_network_acl` and `aws_network_acl_rule`
 # to block ingress traffic from unknown sources to the configured ports
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-21 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -89,7 +90,6 @@ violations = aws_network_acl_rule_violations + aws_network_acl_violations
 
 message = const.message
 if blocked_ports contains 22 or blocked_ports contains 3389 {
-	message += " Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-21 for more details."
 }
 summary = {
 	"policy_name": "ec2-network-acl",

--- a/policies/ec2/ec2-security-group-ingress-traffic-restriction-port.sentinel
+++ b/policies/ec2/ec2-security-group-ingress-traffic-restriction-port.sentinel
@@ -1,5 +1,7 @@
 # This policy requires resources of type `aws_security_group`, `aws_security_group_rule` and `aws_vpc_security_group_ingress_rule`
 # to block ingress traffic from unknown sources to the configured port
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-13 for more details.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-14 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -98,9 +100,7 @@ violations = aws_security_group_rule_violations + aws_security_group_violations 
 
 message = const.message
 if port == 22 {
-	message += " Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-13 for more details."
 } else if port == 3389 {
-	message += " Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-14 for more details."
 }
 summary = {
 	"policy_name": const.policy_name,

--- a/policies/ec2/ec2-security-group-ingress-traffic-restriction-protocol.sentinel
+++ b/policies/ec2/ec2-security-group-ingress-traffic-restriction-protocol.sentinel
@@ -1,5 +1,7 @@
 # This policy requires resources of type `aws_security_group`, `aws_security_group_rule` and `aws_vpc_security_group_ingress_rule`
 # to block ingress traffic from unknown sources to ports 22 and 3389
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-53 for more details.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-54 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -104,9 +106,9 @@ message = const.message
 if prevent_unknown_ipv4_ingress and prevent_unknown_ipv6_ingress {
 	message += " from '0.0.0.0/0' or '::/0'"
 } else if prevent_unknown_ipv4_ingress {
-	message += " from '0.0.0.0/0'. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-53 for more details."
+	message += " from '0.0.0.0/0'"
 } else {
-	message += " from '::/0'. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-54 for more details."
+	message += " from '::/0'"
 }
 summary = {
 	"policy_name": const.policy_name,

--- a/policies/ec2/ec2-vpc-default-security-group-no-traffic.sentinel
+++ b/policies/ec2/ec2-vpc-default-security-group-no-traffic.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type `aws_vpc` to have no traffic for default security group.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -14,7 +15,7 @@ import "collection/maps" as maps
 # Constants
 
 const = {
-	"message":                             "VPC default security group should not allow inbound and outbound traffic. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2 for more details.",
+	"message":                             "VPC default security group should not allow inbound and outbound traffic",
 	"policy_name":                         "ec2-vpc-default-security-group-no-traffic",
 	"config":                              "config",
 	"security_group_id":                   "security_group_id",

--- a/policies/ec2/ec2-vpc-flow-logging-enabled.sentinel
+++ b/policies/ec2/ec2-vpc-flow-logging-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type `aws_vpc` and `aws_default_vpc` to have flow logs enabled.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-6 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -16,7 +17,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":              "ec2-vpc-flow-logging-enabled",
-	"message":                  "VPC resources `aws_vpc` and `aws_default_vpc` must have flow logging. https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-6 for more details.",
+	"message":                  "VPC resources `aws_vpc` and `aws_default_vpc` must have flow logging.",
 	"address":                  "address",
 	"resource_aws_flow_log":    "aws_flow_log",
 	"resource_aws_vpc":         "aws_vpc",

--- a/policies/efs/efs-encryption-at-rest-enabled.sentinel
+++ b/policies/efs/efs-encryption-at-rest-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires that resources of type `aws_efs_file_system` encryption at rest enabled.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-1 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -20,8 +21,8 @@ const = {
 	"kms_key_id":                    "kms_key_id",
 	"constant_value":                "constant_value",
 	"encrypted":                     "encrypted",
-	"encrypted_attr_violation_msg":  "Attribute 'encrypted' should be true for 'aws_efs_file_system' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-1 for more details.",
-	"kms_key_id_attr_violation_msg": "Attribute 'kms_key_id' should be non empty for 'aws_efs_file_system' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-1 for more details.",
+	"encrypted_attr_violation_msg":  "Attribute 'encrypted' should be true for 'aws_efs_file_system' resources",
+	"kms_key_id_attr_violation_msg": "Attribute 'kms_key_id' should be non empty for 'aws_efs_file_system' resources",
 }
 
 # Functions

--- a/policies/iam/iam-no-admin-privileges-allowed-by-policies.sentinel
+++ b/policies/iam/iam-no-admin-privileges-allowed-by-policies.sentinel
@@ -1,4 +1,5 @@
 # IAM policies should not allow administrator privileges to users/roles/groups.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-1 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -90,7 +91,7 @@ build_violation_object = func(resource_addr, module_addr, message) {
 
 policy_document_violations = fetch_policies_allowing_admin_privileges()
 policy_document_violations_list = map policy_document_violations as _, v {
-	build_violation_object(v.address, v.module_address, "IAM policies should not be allow full '*' administrative privileges. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-1 for more details.")
+	build_violation_object(v.address, v.module_address, "IAM policies should not be allow full '*' administrative privileges")
 }
 
 inline_policy_violations = verify_iam_policy_resources_with_inline_policies()

--- a/policies/iam/iam-no-policies-attached-to-users.sentinel
+++ b/policies/iam/iam-no-policies-attached-to-users.sentinel
@@ -1,4 +1,5 @@
 # IAM users should not be directly attached to IAM policies.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-2 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -13,7 +14,7 @@ import "report" as report
 
 const = {
 	"policy_name": "iam-no-policies-attached-to-users",
-	"message":     "IAM policies should not be attached directly to IAM users. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-2 for more details.",
+	"message":     "IAM policies should not be attached directly to IAM users",
 	"resource_aws_iam_user_policy_attachment": "aws_iam_user_policy_attachment",
 	"resource_aws_iam_user_policy":            "aws_iam_user_policy",
 }

--- a/policies/iam/iam-password-expiry.sentinel
+++ b/policies/iam/iam-password-expiry.sentinel
@@ -1,5 +1,6 @@
 # This policy requires that the `max_password_age` attribute of the `aws_iam_account_password_policy`
 # resource is according to CIS standards.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-17 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -29,9 +30,9 @@ const = {
 # Functions
 generate_violation_message = func(violation) {
 	if violation.values[const.max_password_age] is not defined {
-		return "Attribute 'max_password_age' must be less than or equal to " + string(password_expiry_days) + " days for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-17 for more details."
+		return "Attribute 'max_password_age' must be less than or equal to " + string(password_expiry_days) + " days for 'aws_iam_account_password_policy' resources"
 	}
-	return "Attribute 'max_password_age' with value " + string(violation.values[const.max_password_age]) + " must be less than or equal to " + string(password_expiry_days) + " days for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-17 for more details."
+	return "Attribute 'max_password_age' with value " + string(violation.values[const.max_password_age]) + " must be less than or equal to " + string(password_expiry_days) + " days for 'aws_iam_account_password_policy' resources"
 }
 
 # Variables

--- a/policies/iam/iam-password-length.sentinel
+++ b/policies/iam/iam-password-length.sentinel
@@ -1,5 +1,6 @@
 # This policy requires that the `minimum_password_length` attribute of the `aws_iam_account_password_policy`
 # resource is according to CIS standards.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-15 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -27,9 +28,9 @@ const = {
 # Functions
 generate_violation_message = func(violation) {
 	if violation.values[const.minimum_password_length] is not defined {
-		return "Attribute 'minimum_password_length' must be greater than or equal to " + string(password_length) + " for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-15 for more details."
+		return "Attribute 'minimum_password_length' must be greater than or equal to " + string(password_length) + " for 'aws_iam_account_password_policy' resources"
 	}
-	return "Attribute 'minimum_password_length' with value " + string(violation.values[const.minimum_password_length]) + " must be greater than or equal to " + string(password_length) + " for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-15 for more details."
+	return "Attribute 'minimum_password_length' with value " + string(violation.values[const.minimum_password_length]) + " must be greater than or equal to " + string(password_length) + " for 'aws_iam_account_password_policy' resources"
 }
 
 # Variables

--- a/policies/iam/iam-password-lowercase.sentinel
+++ b/policies/iam/iam-password-lowercase.sentinel
@@ -1,5 +1,6 @@
 # This policy requires that the `require_lowercase_characters` attribute of the `aws_iam_account_password_policy`
 # resource is according to CIS standards.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-12 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -16,7 +17,7 @@ const = {
 	"policy_name":                              "iam-password-lowercase",
 	"resource_aws_iam_account_password_policy": "aws_iam_account_password_policy",
 	"require_lowercase_characters":             "require_lowercase_characters",
-	"message":                                  "Attribute 'require_lowercase_characters' must be equal to true for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-12 for more details.",
+	"message":                                  "Attribute 'require_lowercase_characters' must be equal to true for 'aws_iam_account_password_policy' resources",
 }
 
 # Variables

--- a/policies/iam/iam-password-numbers.sentinel
+++ b/policies/iam/iam-password-numbers.sentinel
@@ -1,5 +1,6 @@
 # This policy requires that the `require_numbers` attribute of the `aws_iam_account_password_policy`
 # resource is according to CIS standards
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-14 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -18,7 +19,7 @@ const = {
 	"policy_name":                      "iam-password-numbers",
 	"resource_aws_iam_password_policy": "aws_iam_account_password_policy",
 	"require_numbers":                  "require_numbers",
-	"message":                          "Attribute 'require_numbers' must be equal to true for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-14 for more details.",
+	"message":                          "Attribute 'require_numbers' must be equal to true for 'aws_iam_account_password_policy' resources",
 }
 
 # Variables

--- a/policies/iam/iam-password-reuse.sentinel
+++ b/policies/iam/iam-password-reuse.sentinel
@@ -1,5 +1,6 @@
 # This policy requires that the `password_reuse_prevention` attribute of the `aws_iam_account_password_policy`
 # resource is according to CIS standards
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-16 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -27,9 +28,9 @@ const = {
 # Functions
 generate_violation_message = func(violation) {
 	if violation.values[const.password_reuse_prevention] is not defined {
-		return "Attribute 'password_reuse_prevention' must be equal to " + string(allowed_password_reuse_limit) + " for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-16 for more details."
+		return "Attribute 'password_reuse_prevention' must be equal to " + string(allowed_password_reuse_limit) + " for 'aws_iam_account_password_policy' resources"
 	}
-	return "Attribute 'password_reuse_prevention' with value " + string(violation.values[const.password_reuse_prevention]) + " must be equal to " + string(allowed_password_reuse_limit) + " for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-16 for more details."
+	return "Attribute 'password_reuse_prevention' with value " + string(violation.values[const.password_reuse_prevention]) + " must be equal to " + string(allowed_password_reuse_limit) + " for 'aws_iam_account_password_policy' resources"
 }
 
 # Variables

--- a/policies/iam/iam-password-symbols.sentinel
+++ b/policies/iam/iam-password-symbols.sentinel
@@ -1,5 +1,6 @@
 # This policy requires that the `require_symbols` attribute of the `aws_iam_account_password_policy`
 # resource is according to CIS standards
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-13 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -17,7 +18,7 @@ const = {
 	"policy_name":                              "iam-password-symbols",
 	"resource_aws_iam_account_password_policy": "aws_iam_account_password_policy",
 	"require_symbols":                          "require_symbols",
-	"message":                                  "Attribute 'require_symbols' must be equal to true for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-13 for more details.",
+	"message":                                  "Attribute 'require_symbols' must be equal to true for 'aws_iam_account_password_policy' resources",
 }
 
 # Variables

--- a/policies/iam/iam-password-uppercase.sentinel
+++ b/policies/iam/iam-password-uppercase.sentinel
@@ -1,5 +1,6 @@
 # This policy requires that the `require_uppercase_characters` attribute of the `aws_iam_account_password_policy`
 # resource is according to CIS standards
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-11 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -17,7 +18,7 @@ const = {
 	"policy_name":                  "iam-password-uppercase",
 	"resource_type":                "aws_iam_account_password_policy",
 	"require_uppercase_characters": true,
-	"message":                      "Attribute 'require_uppercase_characters' must be equal to true for 'aws_iam_account_password_policy' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-11 for more details.",
+	"message":                      "Attribute 'require_uppercase_characters' must be equal to true for 'aws_iam_account_password_policy' resources",
 }
 
 # Variables

--- a/policies/kms/kms-key-rotation-enabled.sentinel
+++ b/policies/kms/kms-key-rotation-enabled.sentinel
@@ -1,4 +1,5 @@
 # Key rotation must be enabled for resources of type 'aws_kms_key'
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/kms-controls.html#kms-4 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -18,7 +19,7 @@ const = {
 	"resource_aws_kms_key": "aws_kms_key",
 	"enable_key_rotation":  "enable_key_rotation",
 	"is_enabled":           "is_enabled",
-	"message":              "Attribute 'enable_key_rotation' must be enabled for 'aws_kms_key' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/kms-controls.html#kms-4 for more details.",
+	"message":              "Attribute 'enable_key_rotation' must be enabled for 'aws_kms_key' resources",
 }
 
 # Variables

--- a/policies/rds/rds-encryption-at-rest-enabled.sentinel
+++ b/policies/rds/rds-encryption-at-rest-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type `aws_db_instance` have attribute "storage_encrypted" set to true.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-3 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":              "rds-encryption-at-rest-enabled",
-	"message":                  "Attribute 'storage_encrypted' must be set to true for 'aws_db_instance' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-3 for more details.",
+	"message":                  "Attribute 'storage_encrypted' must be set to true for 'aws_db_instance' resources",
 	"resource_aws_db_instance": "aws_db_instance",
 	"storage_encrypted":        "storage_encrypted",
 }

--- a/policies/rds/rds-minor-version-upgrade-enabled.sentinel
+++ b/policies/rds/rds-minor-version-upgrade-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type 'aws_db_instance' have attribute 'auto_minor_version_upgrade' set to true.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-13 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":                "rds-minor-version-upgrade-enabled",
-	"message":                    "Attribute 'auto_minor_version_upgrade' must be set to true for 'aws_db_instance' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-13 for more details.",
+	"message":                    "Attribute 'auto_minor_version_upgrade' must be set to true for 'aws_db_instance' resources",
 	"resource_aws_db_instance":   "aws_db_instance",
 	"auto_minor_version_upgrade": "auto_minor_version_upgrade",
 }

--- a/policies/rds/rds-public-access-disabled.sentinel
+++ b/policies/rds/rds-public-access-disabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type 'aws_db_instance' have attribute 'publicly_accessible' set to false.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-2 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -15,7 +16,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":              "rds-public-access-disabled",
-	"message":                  "Attribute 'publicly_accessible' must be set to false for 'aws_db_instance' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-2 for more details.",
+	"message":                  "Attribute 'publicly_accessible' must be set to false for 'aws_db_instance' resources",
 	"resource_aws_db_instance": "aws_db_instance",
 	"publicly_accessible":      "publicly_accessible",
 }

--- a/policies/s3/s3-block-public-access-account-level.sentinel
+++ b/policies/s3/s3-block-public-access-account-level.sentinel
@@ -1,5 +1,6 @@
 # This policy verifies if the attributes of the 'aws_s3_account_public_access_block'
 # resource (if present) are in accordance to AWS CIS standards.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-1 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -13,7 +14,7 @@ import "report" as report
 # Constants
 const = {
 	"policy_name":             "s3-block-public-access-account-level",
-	"message":                 "Account level Amazon S3 block public access settings are not compliant. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-1 for more details.",
+	"message":                 "Account level Amazon S3 block public access settings are not compliant",
 	"ignore_public_acls":      "ignore_public_acls",
 	"restrict_public_buckets": "restrict_public_buckets",
 	"block_public_acls":       "block_public_acls",

--- a/policies/s3/s3-block-public-access-bucket-level.sentinel
+++ b/policies/s3/s3-block-public-access-bucket-level.sentinel
@@ -1,5 +1,6 @@
 # This policy verifies if the attributes of the 'aws_s3_bucket_public_access_block'
 # resource (if present) block public access of an S3 general purpose bucket.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-8 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -20,7 +21,7 @@ const = {
 	"policy_name":                                "s3-block-public-access-bucket-level",
 	"module_address":                             "module_address",
 	"address":                                    "address",
-	"message":                                    "Bucket level Amazon S3 block public access settings are not compliant. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-8 for more details.",
+	"message":                                    "Bucket level Amazon S3 block public access settings are not compliant",
 	"resource_aws_s3_bucket":                     "aws_s3_bucket",
 	"resource_aws_s3_bucket_acl":                 "aws_s3_bucket_acl",
 	"module_prefix":                              "module.",

--- a/policies/s3/s3-enable-object-logging-for-events.sentinel
+++ b/policies/s3/s3-enable-object-logging-for-events.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type 'aws_s3_bucket' have object logging enabled for read/write events.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-22 for more details.
 
 # Copyright IBM Corp. 2025, 2026
 # SPDX-License-Identifier: BUSL-1.1
@@ -22,7 +23,7 @@ param event_type default "ReadOnly"
 
 const = {
 	"policy_name":               "s3-enable-object-logging-for-events",
-	"message":                   "Resources of type 'aws_s3_bucket' must have object logging enabled for read/write events through cloudtrail resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-22 for more details",
+	"message":                   "Resources of type 'aws_s3_bucket' must have object logging enabled for read/write events through cloudtrail resources",
 	"resource_s3_bucket":        "aws_s3_bucket",
 	"resource_cloudtrail":       "aws_cloudtrail",
 	"bucket":                    "bucket",

--- a/policies/s3/s3-require-mfa-delete.sentinel
+++ b/policies/s3/s3-require-mfa-delete.sentinel
@@ -1,4 +1,5 @@
 # This policy verifies that all general purpose S3 buckets should have MFA delete enabled in their versioning configuration
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-20 for more details.
 
 # Copyright IBM Corp. 2025, 2026
 # SPDX-License-Identifier: BUSL-1.1
@@ -25,7 +26,7 @@ const = {
 	"status":     "status",
 	"mfa_delete": "mfa_delete",
 	"enabled":    "Enabled",
-	"message":    "All 'aws_s3_bucket' resources should be linked to 'aws_s3_bucket_versioning' resources with 'mfa_delete' set to 'Enabled'. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-20 for more details.",
+	"message":    "All 'aws_s3_bucket' resources should be linked to 'aws_s3_bucket_versioning' resources with 'mfa_delete' set to 'Enabled'",
 }
 
 # Functions

--- a/policies/s3/s3-require-ssl.sentinel
+++ b/policies/s3/s3-require-ssl.sentinel
@@ -1,4 +1,5 @@
 # This policy mandates all requests to 'aws_s3_bucket' resources to use SSL using 'aws_s3_bucket_policy' resource.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5 for more details.
 
 # Copyright IBM Corp. 2025, 2026
 # SPDX-License-Identifier: BUSL-1.1
@@ -25,7 +26,7 @@ const = {
 	"module_prefix":                     "module.",
 	"values":                            "values",
 	"variable":                          "variable",
-	"policy_document_violation_message": "S3 general purpose buckets should require requests to use SSL. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5 for more details.",
+	"policy_document_violation_message": "S3 general purpose buckets should require requests to use SSL",
 	"inline_policy_violation_message":   "All aws_s3_bucket_policy resources must get their policy from an instance of the aws_iam_policy_document data source.",
 }
 

--- a/policies/vpc/vpc-flow-logging-enabled.sentinel
+++ b/policies/vpc/vpc-flow-logging-enabled.sentinel
@@ -1,4 +1,5 @@
 # This policy requires resources of type `aws_vpc` and `aws_default_vpc` to have flow logs enabled.
+# Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-6 for more details.
 
 # Copyright IBM Corp. 2025
 # SPDX-License-Identifier: BUSL-1.1
@@ -16,7 +17,7 @@ import "collection/maps" as maps
 
 const = {
 	"policy_name":              "vpc-flow-logging-enabled",
-	"message":                  "VPC resources `aws_vpc` and `aws_default_vpc` must have flow logging. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-6 for more details.",
+	"message":                  "VPC resources `aws_vpc` and `aws_default_vpc` must have flow logging",
 	"address":                  "address",
 	"resource_aws_flow_log":    "aws_flow_log",
 	"resource_aws_vpc":         "aws_vpc",


### PR DESCRIPTION
## Summary

This PR moves all AWS documentation URLs out of policy violation message strings and into the header comment block of each policy file.

## Changes

- **All 32 policy files**: Inline `Refer to https://...` strings removed from violation messages
- Each file now has `# Refer to <url> for more details.` in the header comment block, after the last description line
- Policy logic and violation message text are unchanged — only the URL placement moves

## Motivation

- Violation messages are surfaced to end-users in Terraform Cloud / HCP Terraform runs; embedding long AWS URLs pollutes the output
- Centralising documentation links in the header makes policies easier to read, maintain, and audit
- Consistent style across all policy libraries

## Testing

All existing test cases pass. No policy logic was modified.